### PR TITLE
Update README to correct link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 <iframe width="640" height="480" src="//www.youtube.com/embed/VQjS7umZeGc?rel=0&modestbranding=1" frameborder="0" allowfullscreen></iframe>
 
-<p><a href="https://www.youtube.com/watch?v=VQjS7umZeGc">HTML Tables</a></p>.
+<p><a href="https://www.youtube.com/watch?v=VQjS7umZeGc">HTML Images</a></p>.


### PR DESCRIPTION
I changed the link text from "HTML Tables" to "HTML Images"